### PR TITLE
Fixed dispatch function when there is no type

### DIFF
--- a/packages/ozone-typescript-client/src/ozoneClient/ozoneClientImpl.ts
+++ b/packages/ozone-typescript-client/src/ozoneClient/ozoneClientImpl.ts
@@ -570,10 +570,8 @@ export class OzoneClientImpl extends StateMachineImpl<ClientState> implements Oz
 	private dispatchMessage(message: DeviceMessage) {
 		if (message.type) {
 			OzoneClientImpl.invokeMessageListeners(message, this._messageListeners[message.type])
-			OzoneClientImpl.invokeMessageListeners(message, this._messageListeners['*'])
-		} else {
-			throw Error('Can not dispatch message of undefined type')
 		}
+		OzoneClientImpl.invokeMessageListeners(message, this._messageListeners['*'])
 	}
 
 	private setupTransitionListeners() {


### PR DESCRIPTION
The function `addMessageListener()` accepts undefined types
But the function `dispatchMessage()` requires a type

It's because you can trigger an action `onAnyMessage`, so the type is not required for this handler. But currently, the billing message has no type (never had one) and it has always been implemented in the front to use the function onAnyMessage that does not require a message type. So the function `dispatchMessage()` should not throw an error when the message is undefined.