### PR TITLE
Removed size and offset setters/getters

### DIFF
--- a/packages/ozone-helper/ozone-search-helper/src/ozone-search-helper.ts
+++ b/packages/ozone-helper/ozone-search-helper/src/ozone-search-helper.ts
@@ -44,9 +44,6 @@ export type BasicOzoneType = string | boolean | number
  * ```
  */
 export class SearchQuery {
-	private size = 10
-	private offset = 0
-
 	_searchRequest: SearchRequest = {
 		size: 10
 	}
@@ -108,7 +105,6 @@ export class SearchQuery {
 	 * @return {SearchQuery} this
 	 */
 	setSize(size: number): SearchQuery {
-		this.size = size
 		this._searchRequest.size = size
 		return this
 	}
@@ -119,7 +115,6 @@ export class SearchQuery {
 	 * @return {SearchQuery} this
 	 */
 	setOffset(offset: number): SearchQuery {
-		this.offset = offset
 		this._searchRequest.offset = offset
 		return this
 	}
@@ -255,7 +250,7 @@ export class SearchQuery {
 	}
 	/**
 	 * Search inside a tenant
-	 * @param {mode} mode
+	 * @param {ModeType} mode
 	 * @param {string} tenantId
 	 * @return {SearchQuery}
 	 */
@@ -275,7 +270,7 @@ export class SearchQuery {
 	 * @return {SearchQuery}
 	 */
 	suggestion(searchString: string, lastTerm: string = '', size?: number) {
-		const suggestSize = size || this.size
+		const suggestSize = size || this._searchRequest.size
 
 		this._searchRequest.aggregations = [{
 			'$type': 'TermsAggregation',

--- a/packages/ozone-helper/ozone-search-helper/src/ozone-search-helper.ts
+++ b/packages/ozone-helper/ozone-search-helper/src/ozone-search-helper.ts
@@ -1,7 +1,7 @@
 /**
  * Created by hubert on 8/06/17.
  */
-import {SearchRequest, TermsAggregation, ExistsQuery, WildcardQuery, QueryStringQuery, TermQuery, ModeType, TermsQuery, TenantQuery, TypeQuery, Query, BoolQuery, Sort, IdsQuery, AggregationItem, RegexpQuery, RangeQuery} from 'ozone-type'
+import { SearchRequest, TermsAggregation, ExistsQuery, WildcardQuery, QueryStringQuery, TermQuery, ModeType, TermsQuery, TenantQuery, TypeQuery, Query, BoolQuery, Sort, IdsQuery, RegexpQuery, RangeQuery } from 'ozone-type'
 export type BoolQueryName = 'mustClauses' | 'shouldClauses' | 'mustNotClauses'
 export type BasicOzoneType = string | boolean | number
 

--- a/packages/ozone-helper/ozone-search-helper/src/ozone-search-helper.ts
+++ b/packages/ozone-helper/ozone-search-helper/src/ozone-search-helper.ts
@@ -1,10 +1,7 @@
 /**
  * Created by hubert on 8/06/17.
  */
-import {Item, SearchRequest, ItemSearchResult, TermsAggregation, Aggregation,
-	ExistsQuery,FromOzone,
-	WildcardQuery, QueryStringQuery, TermQuery, ModeType, TermsQuery, TenantQuery, TypeQuery, Query, BoolQuery, Sort, IdsQuery, AggregationItem, RegexpQuery, RangeQuery} from 'ozone-type'
-
+import {SearchRequest, TermsAggregation, ExistsQuery, WildcardQuery, QueryStringQuery, TermQuery, ModeType, TermsQuery, TenantQuery, TypeQuery, Query, BoolQuery, Sort, IdsQuery, AggregationItem, RegexpQuery, RangeQuery} from 'ozone-type'
 export type BoolQueryName = 'mustClauses' | 'shouldClauses' | 'mustNotClauses'
 export type BasicOzoneType = string | boolean | number
 
@@ -47,6 +44,9 @@ export type BasicOzoneType = string | boolean | number
  * ```
  */
 export class SearchQuery {
+	private size = 10
+	private offset = 0
+
 	_searchRequest: SearchRequest = {
 		size: 10
 	}
@@ -76,11 +76,6 @@ export class SearchQuery {
 	 * searchRequest getter
 	 */
 	get searchRequest (): SearchRequest { return this._searchRequest }
-
-	get size(): number { return this._searchRequest.size || 0 }
-	set size(size: number) { this._searchRequest.size = size }
-	get offset(): number { return this._searchRequest.offset || 0 }
-	set offset(size: number) { this._searchRequest.offset = size }
 
 	/**
 	 * create boolQuery mustClauses.
@@ -114,6 +109,7 @@ export class SearchQuery {
 	 */
 	setSize(size: number): SearchQuery {
 		this.size = size
+		this._searchRequest.size = size
 		return this
 	}
 	/**
@@ -124,6 +120,7 @@ export class SearchQuery {
 	 */
 	setOffset(offset: number): SearchQuery {
 		this.offset = offset
+		this._searchRequest.offset = offset
 		return this
 	}
 
@@ -258,7 +255,7 @@ export class SearchQuery {
 	}
 	/**
 	 * Search inside a tenant
-	 * @param {Mode} mode
+	 * @param {mode} mode
 	 * @param {string} tenantId
 	 * @return {SearchQuery}
 	 */

--- a/packages/ozone-logic/ozone-collection/src/ozone-collection.ts
+++ b/packages/ozone-logic/ozone-collection/src/ozone-collection.ts
@@ -106,7 +106,7 @@ export class OzoneCollection<T extends Item = Item> extends Polymer.Element impl
 	async quickSearch(searchString: string, size?: number): Promise<Array<FromOzone<T>>> {
 		size = size || 10
 		let searchQuery = new SearchQuery()
-		searchQuery.size = size
+		searchQuery.setSize(size)
 		searchQuery.quicksearch(searchString)
 		return this.search(searchQuery)
 	}

--- a/packages/ozone-typescript-client/test/itemClient/itemClient.spec.ts
+++ b/packages/ozone-typescript-client/test/itemClient/itemClient.spec.ts
@@ -66,7 +66,7 @@ describe('OzoneClient', () => {
 			it('should iterate on all the results', async () => {
 				const itemApi = client.itemClient('collection')
 				const searchQuery = new SearchQuery()
-				searchQuery.termQuery('foo', 'bar').size = 2
+				searchQuery.termQuery('foo', 'bar').setSize(2)
 				server.autoRespond = true
 				let expectedResponseIndex = 0
 
@@ -79,7 +79,7 @@ describe('OzoneClient', () => {
 				const itemApi = client.itemClient('collection')
 				const searchQuery = new SearchQuery()
 				const pageSize = 2
-				searchQuery.termQuery('foo', 'bar').size = pageSize
+				searchQuery.termQuery('foo', 'bar').setSize(pageSize)
 
 				const searchGen: any = itemApi.searchGenerator(searchQuery.searchRequest)
 				const res1Promise = searchGen.next()


### PR DESCRIPTION
I removed the setters and getters for `offset` and `size`, which were common properties of SearchRequest and SearchQuery, which allowed SearchQuery to be a valid argument for `itemClient.search()` when it should not.

I checked for the occurence of the getters and setters `.size` and `.offset` in

* ozone-components
* flowr-admin
* flowr-frontend
* flowr-external-app

The getters `.offset` and `.size` were **never** used anywhere, so I didn't implement any new getters for those properties. Most of the time we do `searchQuery.searchRequest.size` or offset so we don't need getters on searchQuery itself.

The setters `.offset` has been replaced by `.setOffset()` and `.size` by `.setSize()`

FlowR PR => https://bitbucket.taktik.be/projects/FLOWR/repos/flowr/pull-requests/4373/overview