### PR TITLE
improve ws parseMessage

### DIFF
--- a/packages/ozone-typescript-client/src/ozoneClient/ozoneClientImpl.ts
+++ b/packages/ozone-typescript-client/src/ozoneClient/ozoneClientImpl.ts
@@ -229,6 +229,10 @@ export class OzoneClientImpl extends StateMachineImpl<ClientState> implements Oz
 
 	private static parseMessage(message: MessageEvent): DeviceMessage | null {
 		try {
+			if (typeof(message.data) === 'string') {
+				OzoneClientImpl.log?.warn('Received string message.data: ' + message)
+				return null
+			}
 			return JSON.parse(message.data) as DeviceMessage
 		} catch (e) {
 			OzoneClientImpl.log?.error('Unable to parse websocket message:', message, '// Error:', e)


### PR DESCRIPTION
Please check FLOW-11048 and tell me if your understanding of the ticket is the same as mine. 
In the end, the behaviour should be exactly the same as before, but with a more clear error message, and a warning instead of an error (and error is already logged in the backend)